### PR TITLE
Change permissions on composer.phar

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -284,6 +284,8 @@ status "Installing dependencies..."
 
 # check if we should use a composer.phar version bundled with the project
 if [[ -f "composer.phar" ]]; then
+    chmod +x composer.phar
+
     [[ -x "composer.phar" ]] || error "File '/composer.phar' isn't executable; please 'chmod +x'!"
     $engine_r 'new Phar("composer.phar");' &> /dev/null || error "File '/composer.phar' is not a valid PHAR archive!"
     composer() {


### PR DESCRIPTION
if the composer.phar is provided then the build fails due to a lack of permissions. 
adding this fixes it. albeit looking kinda hacky.
